### PR TITLE
[bug] `z_track`:ensure_minimum_lifespan_of_one

### DIFF
--- a/sources/z_track.c
+++ b/sources/z_track.c
@@ -415,7 +415,8 @@ void z_track_generate(
                 1
               )
             ) %
-            1000
+            1000 +
+            1
           ) /
           speed *
           (float) track->length /
@@ -433,7 +434,8 @@ void z_track_generate(
                 1
               )
             ) %
-            1000
+            1000 +
+            1
           ) /
           speed *
           (float) track->length /


### PR DESCRIPTION
this fixes the issue of invalid values returned in the io proc by ensuring every note has at least a lifespan of `1`