### PR TITLE
[enh] `z_display_thread`:add::thread_the_display_rendering_and_updates

### DIFF
--- a/include/z_display.h
+++ b/include/z_display.h
@@ -3,12 +3,28 @@
 
 #include <z_queue.h>
 
+struct z_display_data {
+  char* name;
+  char* name_next;
+  char* progress;
+  char* seed;
+};
+
 void z_display_render(
-  struct z_queue*
+  struct z_display_data*
 );
 
-void z_display_render_event(
-  void* z_event_data
+void z_display_data_initialize(
+  struct z_display_data*
+);
+
+void z_display_data_set(
+  struct z_display_data* z_display_data,
+  struct z_queue* z_queue
+);
+
+void z_display_data_destroy(
+  struct z_display_data*
 );
 
 #endif

--- a/include/z_display_thread.h
+++ b/include/z_display_thread.h
@@ -1,0 +1,47 @@
+#ifndef __z_display_thread_h
+#define __z_display_thread_h
+
+#include <z_display.h>
+#include <z_queue.h>
+
+#include <pthread.h>
+
+struct z_display_thread_data {
+  unsigned int index_track;
+
+  pthread_t thread;
+
+  pthread_mutex_t mutex_render;
+
+  float progress;
+  
+  struct z_display_data display_data;
+  struct z_queue* queue;
+
+  unsigned char destroying;
+};
+
+void* z_display_thread(
+  void*
+);
+
+void z_display_thread_initialize(
+  struct z_display_thread_data*,
+  struct z_queue*
+);
+
+void z_display_thread_data_set(
+  struct z_display_thread_data* z_display_thread_data,
+  struct z_queue* z_queue
+);
+
+void z_display_thread_render_event(
+  void*,
+  void*
+);
+
+void z_display_thread_destroy(
+  struct z_display_thread_data*
+);
+
+#endif

--- a/include/z_event.h
+++ b/include/z_event.h
@@ -2,17 +2,33 @@
 #define __z_event_h
 
 enum z_event_type {
-  z_event_type_track_update = 0,
-  z_event_type_track_pregeneration = 1
+  z_event_type_track_pregeneration = 0x00,
+  z_event_type_track_update = 0xff
 };
 
-typedef void (*z_event_function)(
+enum z_event_function_type {
+  z_event_function_type_without_data = 0x00,
+  z_event_function_type_with_data = 0xff
+};
+
+typedef void (*z_event_function_without_data)(
   void*
 );
 
-extern unsigned char z_event_functions_length;
-extern z_event_function* z_event_functions;
-extern enum z_event_type* z_event_types;
+typedef void (*z_event_function_with_data)(
+  void*,
+  void*
+);
+
+struct z_event_function_structure {
+  void* function;
+  enum z_event_type event_type;
+  enum z_event_function_type type;
+  void* data;
+};
+
+extern struct z_event_function_structure** z_event_function_structures;
+extern unsigned int z_event_function_structures_length;
 
 void z_event_initialize();
 
@@ -21,13 +37,26 @@ void z_event_trigger(
   void*
 );
 
-unsigned char z_event_on(
-  z_event_function,
+void z_event_on(
+  z_event_function_without_data,
   enum z_event_type
 );
 
+void z_event_on_with_data(
+  z_event_function_with_data,
+  enum z_event_type,
+  void*
+);
+
+void z_event_function_structures_add(
+  void* function,
+  enum z_event_type event_type,
+  enum z_event_function_type type,
+  void* data
+);
+
 unsigned char z_event_off(
-  z_event_function,
+  void*,
   enum z_event_type
 );
 

--- a/include/z_queue.h
+++ b/include/z_queue.h
@@ -8,6 +8,8 @@
 #include <pthread.h>
 
 struct z_queue {
+  unsigned int index_track;
+
   struct z_track* track_current;
   struct z_track* track_upcoming;
 
@@ -22,6 +24,10 @@ void z_queue_initialize(
   struct z_queue*,
   struct z_track_parameters*,
   float*
+);
+
+void z_queue_track_next(
+  struct z_queue*
 );
 
 void z_queue_destroy(

--- a/include/z_track.h
+++ b/include/z_track.h
@@ -30,6 +30,7 @@ struct z_track {
   unsigned char key;
 
   char* char_array_seed;
+  unsigned int length_char_array_seed;
 
   struct rand_parameters rand_parameters;
   struct rand_result rand_result;

--- a/include/z_words.h
+++ b/include/z_words.h
@@ -7,4 +7,9 @@ extern const char* z_words[
   z_words_length
 ];
 
+void z_words_construct(
+  char**,
+  char*
+);
+
 #endif

--- a/makefile
+++ b/makefile
@@ -98,11 +98,14 @@ file_rand_library:=${shell realpath "${file_rand_library}"}
 files_sources=${wildcard ${directory_sources}/*.c}
 ifeq (${target_os},ios)
 files_sources:=${filter-out ${directory_sources}/z.c,${files_sources}}
+files_sources:=${filter-out ${directory_sources}/z_display.c,${files_sources}}
+files_sources:=${filter-out ${directory_sources}/z_display_thread.c,${files_sources}}
 endif
 files_objects=${patsubst ${directory_sources}/%.c,${directory_objects}/%.o,${files_sources}}
 files_objects_library:=${patsubst ${directory_objects}/%.o,${directory_objects}/%_library.o,${files_objects}}
 files_objects_library:=${filter-out ${directory_objects}/z_library.o,${files_objects_library}}
 files_objects_library:=${filter-out ${directory_objects}/z_display_library.o,${files_objects_library}}
+files_objects_library:=${filter-out ${directory_objects}/z_display_thread_library.o,${files_objects_library}}
 files_libraries=${file_cero_library} ${file_clic3_library} ${file_interrupt_handler_library} ${file_math_c_library} ${file_rand_library}
 
 ifndef target_device_version

--- a/sources/z.c
+++ b/sources/z.c
@@ -1,7 +1,7 @@
 #include <z.h>
 
 #include <z_close_exit.h>
-#include <z_display.h>
+#include <z_display_thread.h>
 #include <z_event.h>
 #include <z_io_proc.h>
 #include <z_io_proc_data.h>
@@ -17,10 +17,8 @@
 #include <pthread.h>
 
 int main() {
-  cer0_signal_sine_alice(
-    1.3f
-  );
-
+  struct cer0_audio_output audio_output;
+  struct z_display_thread_data z_display_thread_data;
   struct z_io_proc_data z_io_proc_data;
   struct z_track_parameters z_track_parameters;
 
@@ -31,8 +29,6 @@ int main() {
   interrupt_handler_interrupt_function_add(
     z_close_exit
   );
-
-  struct cer0_audio_output audio_output;
 
   z_track_parameters_initialize_defaults(
     &z_track_parameters
@@ -46,9 +42,9 @@ int main() {
 
   z_event_initialize();
 
-  z_event_on(
-    z_display_render_event,
-    z_event_type_track_update
+  z_display_thread_initialize(
+    &z_display_thread_data,
+    &z_io_proc_data.queue
   );
 
   cer0_audio_output_initialize(
@@ -80,6 +76,10 @@ int main() {
   );
 
   z_event_destroy();
+
+  z_display_thread_destroy(
+    &z_display_thread_data
+  );
 
   z_queue_destroy(
     &z_io_proc_data.queue

--- a/sources/z_display.c
+++ b/sources/z_display.c
@@ -3,188 +3,140 @@
 #include <z_queue.h>
 #include <z_words.h>
 
+#include <clic3_bytes.h>
+
 #include <clic3_memory.h>
 
-#include <math_c.h>
-
 #include <stdio.h>
-#include <sys/ioctl.h>
 
 void z_display_render(
-  struct z_queue* z_queue
+  struct z_display_data* z_display_data
 ) {
-  struct winsize terminal_size;
-
-  signed char status_ioctl = ioctl(
-    0,
-    TIOCGWINSZ,
-    &terminal_size
-  );
-
-  char* buffer_track_progress;
-
-  if (
-    status_ioctl == -1 ||
-    terminal_size.ws_col < 1
-  ) {
-    buffer_track_progress = (
-      clic3_memory_allocate_raw(
-        0
-      )
-    );
-  } else {
-    unsigned int width = terminal_size.ws_col;
-
-    buffer_track_progress = (
-      clic3_memory_allocate_raw(
-        width +
-        1
-      )
-    );
-
-    buffer_track_progress[0] = (
-      '|'
-    );
-    
-    buffer_track_progress[
-      (width - 1)
-    ] = (
-      '|'
-    );
-
-    buffer_track_progress[
-      width
-    ] = (
-      '\0'
-    );
-
-    unsigned int length_progress_indicators = (
-      (
-        width -
-        1
-      ) *
-      math_c_floating_point_minimum(
-        math_c_floating_point_maximum(
-          z_queue->track_current->progress,
-          0.0f
-        ),
-        1.0f
-      )
-    );
-
-    for (
-      unsigned int index_buffer_track_progress = 1;
-      index_buffer_track_progress < width - 1;
-      ++index_buffer_track_progress
-    ) {
-      if (
-        index_buffer_track_progress <= length_progress_indicators
-      ) {
-        if (
-          index_buffer_track_progress != width - 2 &&
-          index_buffer_track_progress == length_progress_indicators
-        ) {
-          buffer_track_progress[
-            index_buffer_track_progress
-          ] = (
-            '>'
-          );
-        } else {
-          buffer_track_progress[
-            index_buffer_track_progress
-          ] = (
-            '-'
-          );
-        }
-      } else {
-        buffer_track_progress[
-          index_buffer_track_progress
-        ] = (
-          ' '
-        );
-      }
-    }
-  }
-
   printf(
     "\e[?25l"
     "\e[H\e[2J\e[3J"
     "playing_track->{"
-  );
-
-  for (
-    unsigned char index_name = 0;
-    z_queue->track_current->name[
-      index_name
-    ] != '\0';
-    ++index_name
-  ) {
-    printf(
-      index_name != 0
-      ? " %s"
-      : "%s",
-      z_words[
-        z_queue->track_current->name[
-          index_name
-        ] %
-        z_words_length
-      ]
-    );
-  }
-  
-  printf(
+    "%s"
     "}\n"
     "upcoming_track->{"
-  );
-  
-  for (
-    unsigned char index_name = 0;
-    z_queue->track_upcoming->name[
-      index_name
-    ] != '\0';
-    ++index_name
-  ) {
-    printf(
-      index_name != 0
-      ? " %s"
-      : "%s",
-      z_words[
-        z_queue->track_upcoming->name[
-          index_name
-        ] %
-        z_words_length
-      ]
-    );
-  }
-
-  printf(
+    "%s"
     "}\n"
     "\n"
-    // "seed: %s\n"
+    "seed: %s\n"
     "\n%s\n\n"
     ": "
     "\e[?25h",
-    // z_queue->track_current->char_array_seed,
-    buffer_track_progress
+    z_display_data->name,
+    z_display_data->name_next,
+    z_display_data->seed,
+    z_display_data->progress
   );
 
   fflush(
     stdout
   );
+}
 
-  clic3_memory_free_raw(
-    buffer_track_progress
+void z_display_data_initialize(
+  struct z_display_data* z_display_data
+) {
+  z_display_data->name = (
+    clic3_memory_allocate_raw(
+      1
+    )
+  );
+
+  z_display_data->name_next = (
+    clic3_memory_allocate_raw(
+      1
+    )
+  );
+
+  z_display_data->seed = (
+    clic3_memory_allocate_raw(
+      1
+    )
+  );
+
+  z_display_data->progress = (
+    clic3_memory_allocate_raw(
+      1
+    )
+  );
+
+  z_display_data->name[
+    0
+  ] = (
+    '\0'
+  );
+
+  z_display_data->name_next[
+    0
+  ] = (
+    '\0'
+  );
+
+  z_display_data->seed[
+    0
+  ] = (
+    '\0'
+  );
+
+  z_display_data->progress[
+    0
+  ] = (
+    '\0'
   );
 }
 
-void z_display_render_event(
-  void* z_event_data
+void z_display_data_set(
+  struct z_display_data* z_display_data,
+  struct z_queue* z_queue
 ) {
-  struct z_queue* z_queue = (
-    z_event_data
+  clic3_memory_reallocate_raw(
+    &z_display_data->seed,
+    (
+      z_queue->track_current->length_char_array_seed +
+      1
+    )
   );
 
-  z_display_render(
-    z_queue
+  clic3_bytes_copy(
+    z_display_data->seed,
+    z_queue->track_current->char_array_seed,
+    (
+      z_queue->track_current->length_char_array_seed +
+      1
+    )
+  );
+
+  z_words_construct(
+    &z_display_data->name,
+    z_queue->track_current->name
+  );
+
+  z_words_construct(
+    &z_display_data->name_next,
+    z_queue->track_upcoming->name
+  );
+}
+
+void z_display_data_destroy(
+  struct z_display_data* z_display_data
+) {
+  clic3_memory_free_raw(
+    z_display_data->name
+  );
+
+  clic3_memory_free_raw(
+    z_display_data->name_next
+  );
+
+  clic3_memory_free_raw(
+    z_display_data->progress
+  );
+
+  clic3_memory_free_raw(
+    z_display_data->seed
   );
 }

--- a/sources/z_display_thread.c
+++ b/sources/z_display_thread.c
@@ -1,0 +1,256 @@
+#include <z_display_thread.h>
+
+#include <z_display.h>
+#include <z_event.h>
+#include <z_queue.h>
+
+#include <clic3_memory.h>
+
+#include <math_c_maximum.h>
+#include <math_c_minimum.h>
+
+#include <pthread.h>
+#include <sys/ioctl.h>
+
+void* z_display_render_thread(
+  void* data
+) {
+  struct z_display_thread_data* z_display_thread_data = (
+    data
+  );
+
+  while (
+    z_display_thread_data->destroying == 0
+  ) {
+    pthread_mutex_lock(
+      &z_display_thread_data->mutex_render
+    );
+
+    if (
+      z_display_thread_data->destroying != 0
+    ) {
+      continue;
+    }
+    
+    struct winsize terminal_size;
+
+    signed char status_ioctl = ioctl(
+      0,
+      TIOCGWINSZ,
+      &terminal_size
+    );
+
+    if (
+      status_ioctl == -1 ||
+      terminal_size.ws_col < 1
+    ) {
+      clic3_memory_reallocate_raw(
+        &z_display_thread_data->display_data.progress,
+        1
+      );
+
+      z_display_thread_data->display_data.progress[
+        0
+      ] = (
+        '\0'
+      );
+    } else {
+      unsigned int width = terminal_size.ws_col;
+
+      
+      clic3_memory_reallocate_raw(
+        &z_display_thread_data->display_data.progress,
+        (
+          width +
+          1
+        )
+      );
+
+      z_display_thread_data->display_data.progress[
+        0
+      ] = (
+        '|'
+      );
+      
+      z_display_thread_data->display_data.progress[
+        width -
+        1
+      ] = (
+        '|'
+      );
+
+      z_display_thread_data->display_data.progress[
+        width
+      ] = (
+        '\0'
+      );
+
+      unsigned int length_progress_indicators = (
+        (
+          width -
+          1
+        ) *
+        math_c_minimum_float(
+          math_c_maximum_float(
+            z_display_thread_data->progress,
+            0.0f
+          ),
+          1.0f
+        )
+      );
+
+      for (
+        unsigned int index_progress = 1;
+        index_progress < width - 1;
+        ++index_progress
+      ) {
+        if (
+          index_progress <= length_progress_indicators
+        ) {
+          if (
+            index_progress != width - 2 &&
+            index_progress == length_progress_indicators
+          ) {
+            z_display_thread_data->display_data.progress[
+              index_progress
+            ] = (
+              '>'
+            );
+          } else {
+            z_display_thread_data->display_data.progress[
+              index_progress
+            ] = (
+              '-'
+            );
+          }
+        } else {
+          z_display_thread_data->display_data.progress[
+            index_progress
+          ] = (
+            ' '
+          );
+        }
+      }
+    }
+
+    z_display_render(
+      &z_display_thread_data->display_data
+    );
+  }
+
+  return 0;
+}
+
+void z_display_thread_initialize(
+  struct z_display_thread_data* z_display_thread_data,
+  struct z_queue* z_queue
+) {
+  pthread_mutex_init(
+    &z_display_thread_data->mutex_render,
+    0
+  );
+
+  pthread_mutex_lock(
+    &z_display_thread_data->mutex_render
+  );
+
+  z_display_data_initialize(
+    &z_display_thread_data->display_data
+  );
+
+  z_display_thread_data->index_track = 10100101;
+
+  z_display_thread_data->destroying = (
+    0
+  );
+
+  pthread_create(
+    &z_display_thread_data->thread,
+    0,
+    z_display_render_thread,
+    z_display_thread_data
+  );
+
+  z_event_on_with_data(
+    z_display_thread_render_event,
+    z_event_type_track_update,
+    z_display_thread_data
+  );
+}
+
+void z_display_thread_data_set(
+  struct z_display_thread_data* z_display_thread_data,
+  struct z_queue* z_queue
+) {
+  z_display_thread_data->index_track = (
+    z_queue->index_track
+  );
+
+  z_display_data_set(
+    &z_display_thread_data->display_data,
+    z_queue
+  );
+}
+
+void z_display_thread_render_event(
+  void* z_event_data,
+  void* z_event_structure_function_data
+) {
+  struct z_queue* z_queue = (
+    z_event_data
+  );
+
+  struct z_display_thread_data* z_display_thread_data = (
+    z_event_structure_function_data
+  );
+
+  if (
+    z_display_thread_data->queue !=
+    z_queue
+  ) {
+    z_display_thread_data->queue = (
+      z_queue
+    );
+  }
+
+  z_display_thread_data->progress = (
+    z_display_thread_data->queue->track_current->progress
+  );
+
+  if (
+    z_queue->index_track !=
+    z_display_thread_data->index_track
+  ) {
+    z_display_thread_data_set(
+      z_display_thread_data,
+      z_queue
+    );
+  }
+
+  pthread_mutex_unlock(
+    &z_display_thread_data->mutex_render
+  );
+}
+
+void z_display_thread_destroy(
+  struct z_display_thread_data* z_display_thread_data
+) {
+  z_display_thread_data->destroying = 1;
+
+  pthread_mutex_unlock(
+    &z_display_thread_data->mutex_render
+  );
+
+  pthread_join(
+    z_display_thread_data->thread,
+    0
+  );
+
+  pthread_mutex_destroy(
+    &z_display_thread_data->mutex_render
+  );
+
+  z_display_data_destroy(
+    &z_display_thread_data->display_data
+  );
+}

--- a/sources/z_display_thread.c
+++ b/sources/z_display_thread.c
@@ -31,6 +31,20 @@ void* z_display_render_thread(
     ) {
       continue;
     }
+
+    z_display_thread_data->progress = (
+      z_display_thread_data->queue->track_current->progress
+    );
+
+    if (
+      z_display_thread_data->queue->index_track !=
+      z_display_thread_data->index_track
+    ) {
+      z_display_thread_data_set(
+        z_display_thread_data,
+        z_display_thread_data->queue
+      );
+    }
     
     struct winsize terminal_size;
 
@@ -209,20 +223,6 @@ void z_display_thread_render_event(
     z_queue
   ) {
     z_display_thread_data->queue = (
-      z_queue
-    );
-  }
-
-  z_display_thread_data->progress = (
-    z_display_thread_data->queue->track_current->progress
-  );
-
-  if (
-    z_queue->index_track !=
-    z_display_thread_data->index_track
-  ) {
-    z_display_thread_data_set(
-      z_display_thread_data,
       z_queue
     );
   }

--- a/sources/z_event.c
+++ b/sources/z_event.c
@@ -2,32 +2,18 @@
 
 #include <clic3_memory.h>
 
-unsigned char z_event_functions_length = 0;
-
-z_event_function* z_event_functions = (
-  (void*) 0
+unsigned int z_event_function_structures_length = (
+  0
 );
 
-enum z_event_type* z_event_types = (
-  (void*) 0
+struct z_event_function_structure** z_event_function_structures = (
+  0
 );
 
 void z_event_initialize() {
-  z_event_functions = (
+  z_event_function_structures = (
     clic3_memory_allocate_raw(
-      sizeof(
-        z_event_function
-      ) *
-      z_event_functions_length
-    )
-  );
-
-  z_event_types = (
-    clic3_memory_allocate_raw(
-      sizeof(
-        enum z_event_type
-      ) *
-      z_event_functions_length
+      0
     )
   );
 }
@@ -37,150 +23,229 @@ void z_event_trigger(
   void* z_event_data
 ) {
   for (
-    unsigned char index_z_event_function = 0;
-    index_z_event_function < z_event_functions_length;
-    ++index_z_event_function
+    unsigned char index_z_event_function_structure = 0;
+    index_z_event_function_structure < z_event_function_structures_length;
+    ++index_z_event_function_structure
   ) {
+    struct z_event_function_structure* z_event_function_structure = (
+      z_event_function_structures[
+        index_z_event_function_structure
+      ]
+    );
+
     if (
-      z_event_types[
-        index_z_event_function
-      ] == z_event_type
+      z_event_function_structure->event_type != z_event_type
     ) {
-      z_event_functions[
-        index_z_event_function
-      ](
-        z_event_data
-      );
+      continue;
+    }
+
+    switch (
+      z_event_function_structure->type
+    ) {
+      case z_event_function_type_with_data: {
+        z_event_function_with_data z_event_function_structure_function = (
+          z_event_function_structure->function
+        );
+
+        void* z_event_function_structure_data = (
+          z_event_function_structure->data
+        );
+
+        z_event_function_structure_function(
+          z_event_data,
+          z_event_function_structure_data
+        );
+
+        break;
+      }
+      case z_event_function_type_without_data: {
+        z_event_function_without_data z_event_function_structure_function = (
+          z_event_function_structure->function
+        );
+
+        z_event_function_structure_function(
+          z_event_data
+        );
+
+        break;
+      }
+      default: {
+        break;
+      }
     }
   }
 }
 
-unsigned char z_event_on(
-  z_event_function z_event_function,
+void z_event_on(
+  z_event_function_without_data z_event_function,
   enum z_event_type z_event_type
 ) {
-  if (
-    z_event_functions_length >= 255
-  ) {
-    return 1;
-  }
+  z_event_function_structures_add(
+    z_event_function,
+    z_event_type,
+    z_event_function_type_without_data,
+    0
+  );
+}
 
-  z_event_functions_length = (
-    z_event_functions_length +
+void z_event_on_with_data(
+  z_event_function_with_data z_event_function,
+  enum z_event_type z_event_type,
+  void* z_event_function_data
+) {
+  z_event_function_structures_add(
+    z_event_function,
+    z_event_type,
+    z_event_function_type_with_data,
+    z_event_function_data
+  );
+}
+
+void z_event_function_structures_add(
+  void* z_event_function_structure_function,
+  enum z_event_type z_event_function_structure_event_type,
+  enum z_event_function_type z_event_function_structure_type,
+  void* z_event_function_structure_data
+) {
+  unsigned int index_z_event_function_structure = (
+    z_event_function_structures_length
+  );
+
+  z_event_function_structures_length = (
+    z_event_function_structures_length +
     1
   );
 
   clic3_memory_reallocate_raw(
-    &z_event_functions,
+    &z_event_function_structures,
     (
       sizeof(
-        z_event_function
+        struct z_event_function_structure
       ) *
-      z_event_functions_length
+      z_event_function_structures_length
     )
   );
 
-  clic3_memory_reallocate_raw(
-    &z_event_types,
-    (
+  z_event_function_structures[
+    index_z_event_function_structure
+  ] = (
+    clic3_memory_allocate_raw(
       sizeof(
-        enum z_event_type
-      ) *
-      z_event_functions_length
+        struct z_event_function_structure
+      )
     )
   );
 
-  z_event_functions[
-    z_event_functions_length -
-    1
-  ] = (
-    z_event_function
+  struct z_event_function_structure* z_event_function_structure = (
+    z_event_function_structures[
+      z_event_function_structures_length -
+      1
+    ]
   );
 
-  z_event_types[
-    z_event_functions_length
-  ] = (
-    z_event_type
+  z_event_function_structure->function = (
+    z_event_function_structure_function
   );
 
-  return 0;
+  z_event_function_structure->event_type = (
+    z_event_function_structure_event_type
+  );
+
+  z_event_function_structure->type = (
+    z_event_function_structure_type
+  );
+
+  z_event_function_structure->data = (
+    z_event_function_structure_data
+  );
 }
 
 unsigned char z_event_off(
-  z_event_function z_event_function,
-  enum z_event_type z_event_type
+  void* z_event_function_structure_function,
+  enum z_event_type z_event_function_structure_event_type
 ) {
   for (
-    unsigned char index_z_event_function = 0;
-    index_z_event_function < z_event_functions_length;
-    ++index_z_event_function
+    unsigned char index_z_event_function_structure = 0;
+    index_z_event_function_structure < z_event_function_structures_length;
+    ++index_z_event_function_structure
   ) {
-    if (
-      z_event_functions[
-        index_z_event_function
-      ] &&
-      z_event_types[
-        index_z_event_function
+    struct z_event_function_structure* z_event_function_structure = (
+      z_event_function_structures[
+        index_z_event_function_structure
       ]
+    );
+
+    if (
+      z_event_function_structure != z_event_function_structure_function ||
+      z_event_function_structure->event_type != z_event_function_structure_event_type
     ) {
-      for (
-        unsigned char index_z_event_function_removal = index_z_event_function;
-        index_z_event_function_removal < z_event_functions_length - 1;
-        ++index_z_event_function_removal
-      ) {
-        z_event_functions[
-          index_z_event_function_removal
-        ] = z_event_functions[
-          index_z_event_function_removal +
-          1
-        ];
-
-        z_event_types[
-          index_z_event_function_removal
-        ] = z_event_types[
-          index_z_event_function_removal +
-          1
-        ];
-      }
-
-      z_event_functions_length = (
-        z_event_functions_length -
-        1
-      );
-
-      clic3_memory_reallocate_raw(
-        &z_event_functions,
-        (
-          sizeof(
-            z_event_function
-          ) *
-          z_event_functions_length
-        )
-      );
-
-      clic3_memory_reallocate_raw(
-        &z_event_types,
-        (
-          sizeof(
-            enum z_event_type
-          ) *
-          z_event_functions_length
-        )
-      );
-
-      return 1;
+      continue;
     }
+
+    clic3_memory_free_raw(
+      z_event_function_structure
+    );
+
+    for (
+      unsigned char index_z_event_function_structure_removal = index_z_event_function_structure;
+      (
+        index_z_event_function_structure_removal < 
+        (
+          z_event_function_structures_length -
+          1
+        )
+      );
+      ++index_z_event_function_structure_removal
+    ) {
+      z_event_function_structures[
+        index_z_event_function_structure_removal
+      ] = (
+        z_event_function_structures[
+          index_z_event_function_structure_removal +
+          1
+        ]
+      );
+    }
+
+    z_event_function_structures_length = (
+      z_event_function_structures_length -
+      1
+    );
+
+    clic3_memory_reallocate_raw(
+      &z_event_function_structures,
+      (
+        sizeof(
+          z_event_function_structure
+        ) *
+        z_event_function_structures_length
+      )
+    );
+
+    return 0;
   }
 
-  return 0;
+  return 1;
 }
 
 void z_event_destroy() {
-  clic3_memory_free_raw(
-    z_event_functions
-  );
+  for (
+    unsigned char index_z_event_function_structure = 0;
+    index_z_event_function_structure < z_event_function_structures_length;
+    ++index_z_event_function_structure
+  ) {
+    struct z_event_function_structure* z_event_function_structure = (
+      z_event_function_structures[
+        index_z_event_function_structure
+      ]
+    );
+
+    clic3_memory_free_raw(
+      z_event_function_structure
+    );
+  }
 
   clic3_memory_free_raw(
-    z_event_types
+    z_event_function_structures
   );
 }

--- a/sources/z_io_proc.c
+++ b/sources/z_io_proc.c
@@ -319,39 +319,7 @@ void z_io_proc_frame_get(
     ) {
       z_io_proc_data ->frame = 0;
 
-      z_track_destroy(
-        z_queue->track_current
-      );
-
-      clic3_memory_free_raw(
-        z_queue->track_current
-      );
-
-      z_queue->track_current = (
-        z_queue->track_upcoming
-      );
-
-      z_queue->track_upcoming = (
-        clic3_memory_allocate_raw(
-          sizeof(
-            struct z_track
-          )
-        )
-      );
-
-      z_event_trigger(
-        z_event_type_track_pregeneration,
-        z_queue
-      );
-
-      z_track_generate(
-        z_queue->track_upcoming,
-        z_queue->track_parameters,
-        *z_queue->rate_sample
-      );
-
-      z_event_trigger(
-        z_event_type_track_update,
+      z_queue_track_next(
         z_queue
       );
     }

--- a/sources/z_queue.c
+++ b/sources/z_queue.c
@@ -1,6 +1,7 @@
 #include <z_queue.h>
 
 #include <z_display.h>
+#include <z_event.h>
 #include <z_queue_status.h>
 #include <z_track.h>
 
@@ -11,7 +12,13 @@ void z_queue_initialize(
   struct z_track_parameters* z_track_parameters,
   float* rate_sample
 ) {
-  z_queue->rate_sample = rate_sample;
+  z_queue->index_track = (
+    0
+  );
+
+  z_queue->rate_sample = (
+    rate_sample
+  );
 
   z_queue->track_current = (
     clic3_memory_allocate_raw(
@@ -43,6 +50,51 @@ void z_queue_initialize(
     z_queue->track_upcoming,
     z_queue->track_parameters,
     *z_queue->rate_sample
+  );
+}
+
+void z_queue_track_next(
+  struct z_queue* z_queue
+) {
+  z_track_destroy(
+    z_queue->track_current
+  );
+
+  clic3_memory_free_raw(
+    z_queue->track_current
+  );
+
+  z_queue->track_current = (
+    z_queue->track_upcoming
+  );
+
+  z_queue->track_upcoming = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct z_track
+      )
+    )
+  );
+
+  z_queue->index_track = (
+    z_queue->index_track +
+    1
+  );
+
+  z_event_trigger(
+    z_event_type_track_pregeneration,
+    z_queue
+  );
+
+  z_track_generate(
+    z_queue->track_upcoming,
+    z_queue->track_parameters,
+    *z_queue->rate_sample
+  );
+
+  z_event_trigger(
+    z_event_type_track_update,
+    z_queue
   );
 }
 

--- a/sources/z_track.c
+++ b/sources/z_track.c
@@ -56,7 +56,9 @@ void z_track_generate(
   );
 
   unsigned char size_float = (
-    sizeof(float)
+    sizeof(
+      float
+    )
   );
 
   rand_get(
@@ -85,10 +87,14 @@ void z_track_generate(
     track->rand_source.data
   );
 
+  track->length_char_array_seed = (
+    rand_source_divisive_data->length_seed +
+    rand_source_divisive_data->length_seed
+  );
+
   track->char_array_seed = (
     clic3_memory_allocate_raw(
-      rand_source_divisive_data->length_seed +
-      rand_source_divisive_data->length_seed +
+      track->length_char_array_seed +
       1
     )
   );
@@ -127,8 +133,7 @@ void z_track_generate(
   }
 
   track->char_array_seed[
-    rand_source_divisive_data->length_seed +
-    rand_source_divisive_data->length_seed
+    track->length_char_array_seed
   ] = '\0';
 
   track->note_table = cer0_note_table_create(
@@ -616,33 +621,6 @@ void z_track_generate(
         ) +
         z_track_parameters->note_release_minimum
       );
-
-      // float note_offset = (
-      //   (float)
-      //   track->rand_result.bytes[2]
-      //   /
-      //   255.0f *
-      //   0.0001f
-      // );
-
-      // float length_note = (
-      //   (float) (
-      //     (
-      //       (
-      //         track->rand_result.bytes[0] +
-      //         1
-      //       ) * (
-      //         track->rand_result.bytes[1] +
-      //         1
-      //       )
-      //     ) %
-      //     1000 +
-      //     1
-      //   ) /
-      //   (speed + 1) *
-      //   (float) track->length /
-      //   (float) track_lane->length_notes
-      // );
 
       float length_note;
 

--- a/sources/z_words.c
+++ b/sources/z_words.c
@@ -1,5 +1,9 @@
 #include <z_words.h>
 
+#include <clic3_bytes.h>
+#include <clic3_char_arrays.h>
+#include <clic3_memory.h>
+
 const char* z_words[
   z_words_length
 ] = {
@@ -81,3 +85,99 @@ const char* z_words[
   "cosmic",
   "radiance"
 };
+
+void z_words_construct(
+  char** words_constructed,
+  char* words
+) {
+  unsigned int length_name = 0;
+  unsigned int length_name_next = 0;
+
+  unsigned int offset_name = 0;
+  unsigned int offset_name_next = 0;
+
+  for (
+    unsigned char index_name = 0;
+    words[
+      index_name
+    ] != '\0';
+    ++index_name
+  ) {
+    unsigned int index_word = (
+      words[
+        index_name
+      ] %
+      z_words_length
+    );
+
+    char* char_array_word = (
+      (char*)
+      z_words[
+        index_word
+      ]
+    );
+
+    unsigned int length_word = (
+      clic3_char_array_length(
+        char_array_word
+      )
+    );
+
+    length_name = (
+      length_name +
+      (
+        index_name > 0
+        ? 1
+        : 0
+      ) +
+      length_word
+    );
+
+    clic3_memory_reallocate_raw(
+      words_constructed,
+      length_name
+    );
+
+    if (
+      index_name > 0
+    ) {
+      (*words_constructed)[
+        offset_name
+      ] = (
+        ' '
+      );
+
+      offset_name = (
+        offset_name +
+        1
+      );
+    }
+
+    clic3_bytes_copy(
+      (
+        (*words_constructed) +
+        offset_name
+      ),
+      char_array_word,
+      length_word
+    );
+
+    offset_name = (
+      length_name
+    );
+  }
+
+  clic3_memory_reallocate_raw(
+    words_constructed,
+    (
+      length_name +
+      1
+    )
+  );
+
+  (*words_constructed)[
+    length_name
+  ] = (
+    '\0'
+  );
+}


### PR DESCRIPTION
- `z_display_thread`:add
- - multi-thread display rendering and updating
- - prevents display updates causing audio buffering issues
- - only computes char arrays for name, name_next, and seed once during each track update


https://github.com/user-attachments/assets/34a91955-0bca-4fbf-8211-c92b6cfc6610


https://github.com/user-attachments/assets/76f2e069-a6dd-4b71-893f-1be526ceb71b

<img width="1920" height="338" alt="Screenshot 2026-02-05 at 16 44 22" src="https://github.com/user-attachments/assets/dc091a52-a568-4ae8-8328-6d8c29f98ac5" />
