### PR TITLE
[enh] Display threading display data set within thread

### DIFF
--- a/sources/z_display_thread.c
+++ b/sources/z_display_thread.c
@@ -31,6 +31,20 @@ void* z_display_render_thread(
     ) {
       continue;
     }
+
+    z_display_thread_data->progress = (
+      z_display_thread_data->queue->track_current->progress
+    );
+
+    if (
+      z_display_thread_data->queue->index_track !=
+      z_display_thread_data->index_track
+    ) {
+      z_display_thread_data_set(
+        z_display_thread_data,
+        z_display_thread_data->queue
+      );
+    }
     
     struct winsize terminal_size;
 
@@ -209,20 +223,6 @@ void z_display_thread_render_event(
     z_queue
   ) {
     z_display_thread_data->queue = (
-      z_queue
-    );
-  }
-
-  z_display_thread_data->progress = (
-    z_display_thread_data->queue->track_current->progress
-  );
-
-  if (
-    z_queue->index_track !=
-    z_display_thread_data->index_track
-  ) {
-    z_display_thread_data_set(
-      z_display_thread_data,
       z_queue
     );
   }


### PR DESCRIPTION
- `z_display_thread`
- - set values within thread rather than within the event function
- - prevents audio buffering issues during the beginning of tracks