### PR TITLE
[bug|enh] `z_initializer`:add

### DIFF
--- a/include/z_close_exit.h
+++ b/include/z_close_exit.h
@@ -3,9 +3,16 @@
 
 #include <pthread.h>
 
-extern pthread_mutex_t z_close_exit_mutex;
+struct z_close_exit_data {
+  pthread_mutex_t mutex_close_exit;
+  pthread_mutex_t mutex_initializer;
 
-void z_close_exit_initialize();
-void z_close_exit();
+  unsigned int initializing;
+};
+
+void z_close_exit(
+  int,
+  void*
+);
 
 #endif

--- a/include/z_initializer.h
+++ b/include/z_initializer.h
@@ -1,0 +1,12 @@
+#ifndef __z_initializer_h
+#define __z_initializer_h
+
+void* z_initializer_thread_display(
+  void*
+);
+
+void* z_initializer_thread(
+  void*
+);
+
+#endif

--- a/include/z_io_proc_data.h
+++ b/include/z_io_proc_data.h
@@ -1,9 +1,10 @@
 #ifndef __z_io_proc_data_h
 #define __z_io_proc_data_h
 
+#include <z_close_exit.h>
 #include <z_queue.h>
-#include <z_track_parameters.h>
 #include <z_settings.h>
+#include <z_track_parameters.h>
 
 #include <pthread.h>
 
@@ -24,6 +25,8 @@ struct z_io_proc_data {
   pthread_mutex_t mutex_playing;
 
   float* rate_sample;
+
+  struct z_close_exit_data* z_close_exit_data;
 };
 
 void z_io_proc_data_initialize(

--- a/sources/z.c
+++ b/sources/z.c
@@ -39,11 +39,6 @@ int main() {
     0
   );
 
-  pthread_join(
-    thread_initializer,
-    0
-  );
-
   struct cer0_audio_output audio_output;
   struct z_display_thread_data z_display_thread_data;
   struct z_io_proc_data z_io_proc_data;
@@ -72,6 +67,11 @@ int main() {
   z_display_thread_initialize(
     &z_display_thread_data,
     &z_io_proc_data.queue
+  );
+
+  pthread_join(
+    thread_initializer,
+    0
   );
 
   cer0_audio_output_initialize(

--- a/sources/z.c
+++ b/sources/z.c
@@ -3,6 +3,7 @@
 #include <z_close_exit.h>
 #include <z_display_thread.h>
 #include <z_event.h>
+#include <z_initializer.h>
 #include <z_io_proc.h>
 #include <z_io_proc_data.h>
 #include <z_queue.h>
@@ -17,6 +18,32 @@
 #include <pthread.h>
 
 int main() {
+  unsigned char initializing = (
+    1
+  );
+
+  pthread_t thread_initializer;
+  pthread_t thread_initializer_display;
+
+  pthread_create(
+    &thread_initializer_display,
+    0,
+    z_initializer_thread_display,
+    &initializing
+  );
+
+  pthread_create(
+    &thread_initializer,
+    0,
+    z_initializer_thread,
+    0
+  );
+
+  pthread_join(
+    thread_initializer,
+    0
+  );
+
   struct cer0_audio_output audio_output;
   struct z_display_thread_data z_display_thread_data;
   struct z_io_proc_data z_io_proc_data;
@@ -51,6 +78,15 @@ int main() {
     &audio_output,
     z_io_proc,
     &z_io_proc_data
+  );
+
+  initializing = (
+    0
+  );
+
+  pthread_join(
+    thread_initializer_display,
+    0
   );
 
   pthread_mutex_lock(

--- a/sources/z.c
+++ b/sources/z.c
@@ -18,25 +18,45 @@
 #include <pthread.h>
 
 int main() {
-  unsigned char initializing = (
-    1
-  );
-
   pthread_t thread_initializer;
   pthread_t thread_initializer_display;
+
+  struct z_close_exit_data z_close_exit_data = {
+    .initializing = (
+      1
+    )
+  };
+
+  pthread_mutex_init(
+    &z_close_exit_data.mutex_initializer,
+    0
+  );
+
+  pthread_mutex_lock(
+    &z_close_exit_data.mutex_initializer
+  );
+
+  pthread_mutex_init(
+    &z_close_exit_data.mutex_close_exit,
+    0
+  );
+
+  pthread_mutex_lock(
+    &z_close_exit_data.mutex_close_exit
+  );
 
   pthread_create(
     &thread_initializer_display,
     0,
     z_initializer_thread_display,
-    &initializing
+    &z_close_exit_data.initializing
   );
 
   pthread_create(
     &thread_initializer,
     0,
     z_initializer_thread,
-    0
+    &z_close_exit_data.mutex_initializer
   );
 
   struct cer0_audio_output audio_output;
@@ -44,12 +64,11 @@ int main() {
   struct z_io_proc_data z_io_proc_data;
   struct z_track_parameters z_track_parameters;
 
-  z_close_exit_initialize();
-
   interrupt_handler_initialize();
 
-  interrupt_handler_interrupt_function_add(
-    z_close_exit
+  interrupt_handler_interrupt_function_add_with_data(
+    z_close_exit,
+    &z_close_exit_data
   );
 
   z_track_parameters_initialize_defaults(
@@ -69,38 +88,44 @@ int main() {
     &z_io_proc_data.queue
   );
 
-  pthread_join(
-    thread_initializer,
-    0
-  );
-
-  cer0_audio_output_initialize(
-    &audio_output,
-    z_io_proc,
-    &z_io_proc_data
-  );
-
-  initializing = (
-    0
-  );
-
-  pthread_join(
-    thread_initializer_display,
-    0
-  );
-
   pthread_mutex_lock(
-    &z_close_exit_mutex
+    &z_close_exit_data.mutex_initializer
   );
 
-  z_io_proc_data.exiting = 1;
+  if (
+    interrupt_handler_interrupted == 0
+  ) {
+    z_io_proc_data.z_close_exit_data = (
+      &z_close_exit_data
+    );
 
-  pthread_mutex_lock(
-    &z_io_proc_data.mutex_exited
+    cer0_audio_output_initialize(
+      &audio_output,
+      z_io_proc,
+      &z_io_proc_data
+    );
+
+    pthread_mutex_lock(
+      &z_close_exit_data.mutex_close_exit
+    );
+
+    z_io_proc_data.exiting = 1;
+
+    pthread_mutex_lock(
+      &z_io_proc_data.mutex_exited
+    );
+
+    cer0_audio_output_destroy(
+      &audio_output
+    );
+  }
+
+  pthread_mutex_destroy(
+    &z_close_exit_data.mutex_close_exit
   );
 
-  cer0_audio_output_destroy(
-    &audio_output
+  pthread_mutex_destroy(
+    &z_close_exit_data.mutex_initializer
   );
 
   pthread_mutex_destroy(
@@ -108,7 +133,7 @@ int main() {
   );
 
   pthread_mutex_destroy(
-    &z_io_proc_data.mutex_exited
+    &z_io_proc_data.mutex_playing
   );
 
   z_event_destroy();
@@ -117,9 +142,13 @@ int main() {
     &z_display_thread_data
   );
 
-  z_queue_destroy(
-    &z_io_proc_data.queue
-  );
+  if (
+    z_io_proc_data.initialized != 0
+  ) {
+    z_queue_destroy(
+      &z_io_proc_data.queue
+    );
+  }
 
   z_track_parameters_destroy(
     &z_track_parameters

--- a/sources/z_close_exit.c
+++ b/sources/z_close_exit.c
@@ -1,20 +1,21 @@
 #include <z_close_exit.h>
 
-pthread_mutex_t z_close_exit_mutex;
+#include <pthread.h>
+#include <stdio.h>
 
-void z_close_exit_initialize() {
-  pthread_mutex_init(
-    &z_close_exit_mutex,
-    (void*)0
+void z_close_exit(
+  int status,
+  void* data
+) {
+  struct z_close_exit_data* z_close_exit_data = (
+    data
   );
 
-  pthread_mutex_lock(
-    &z_close_exit_mutex
-  );
-}
-
-void z_close_exit() {
   pthread_mutex_unlock(
-    &z_close_exit_mutex
+    &z_close_exit_data->mutex_initializer
+  );
+
+  pthread_mutex_unlock(
+    &z_close_exit_data->mutex_close_exit
   );
 }

--- a/sources/z_close_exit.c
+++ b/sources/z_close_exit.c
@@ -1,7 +1,6 @@
 #include <z_close_exit.h>
 
 #include <pthread.h>
-#include <stdio.h>
 
 void z_close_exit(
   int status,

--- a/sources/z_initializer.c
+++ b/sources/z_initializer.c
@@ -68,8 +68,16 @@ void* z_initializer_thread_display(
 void* z_initializer_thread(
   void* data
 ) {
+  pthread_mutex_t* mutex_initializer = (
+    data
+  );
+
   cer0_signal_sine_alice(
     333.333f
+  );
+
+  pthread_mutex_unlock(
+    mutex_initializer
   );
 
   return (

--- a/sources/z_initializer.c
+++ b/sources/z_initializer.c
@@ -1,0 +1,78 @@
+#include <z_initializer.h>
+
+#include <cer0_signal.h>
+
+#include <pthread.h>
+#include <stdio.h>
+#include <time.h>
+
+void* z_initializer_thread_display(
+  void* data
+) {
+  unsigned char* initializing = (
+    data
+  );
+
+  unsigned char length_dots = (
+    0
+  );
+
+  struct timespec timespec_sleep = {
+    .tv_sec = 0,
+    .tv_nsec = 250000000
+  };
+
+  struct timespec timespec_sleep_remaining;
+
+  while (
+    *initializing == 1
+  ) {
+    printf(
+      "\e[H\e[2J\e[3J"
+      "z::initializing"
+    );
+
+    for (
+      unsigned char index_dot = 0;
+      index_dot < length_dots;
+      ++index_dot
+    ) {
+      printf(
+        "."
+      );
+    }
+
+    printf(
+      "\n"
+    );
+
+    length_dots = (
+      (
+        length_dots +
+        1
+      ) %
+      4
+    );
+    
+    nanosleep(
+      &timespec_sleep,
+      &timespec_sleep_remaining
+    );
+  }
+
+  return (
+    0
+  );
+}
+
+void* z_initializer_thread(
+  void* data
+) {
+  cer0_signal_sine_alice(
+    333.333f
+  );
+
+  return (
+    0
+  );
+}

--- a/sources/z_io_proc.c
+++ b/sources/z_io_proc.c
@@ -66,6 +66,10 @@ int z_io_proc(
       z_io_proc_data->rate_sample
     );
 
+    z_io_proc_data->z_close_exit_data->initializing = (
+      0
+    );
+
     z_io_proc_data->initialized = 1;
   }
 

--- a/sources/z_io_proc_data.c
+++ b/sources/z_io_proc_data.c
@@ -20,12 +20,12 @@ void z_io_proc_data_initialize(
 
   pthread_mutex_init(
     &z_io_proc_data->mutex_exited,
-    (void*)0
+    0
   );
 
   pthread_mutex_init(
     &z_io_proc_data->mutex_playing,
-    (void*)0
+    0
   );
 
   pthread_mutex_lock(


### PR DESCRIPTION
- `z_initializer`:add
- - adds a initializing display thread
- - adds an initializer_thread
- - prevents audio muting from `cer0_signal_sine_alic3` caching delays


https://github.com/user-attachments/assets/11ad2af7-b803-4316-a2c1-0fd7b2b1bc31

