### PR TITLE
[dev] `z`:modulus_value_polling_by_channel_length

### DIFF
--- a/sources/z.c
+++ b/sources/z.c
@@ -166,7 +166,7 @@ int main(
       if (
         (
           frame %
-          0x02
+          wave_parameters.length_channels
         ) ==
         0x00
       ){


### PR DESCRIPTION
- `z`:modulus_value_polling_by_channel_length