### PR TITLE
[dev] `z_export`:add

### DIFF
--- a/include/z_export.h
+++ b/include/z_export.h
@@ -1,0 +1,28 @@
+#ifndef __z_export_h
+#define __z_export_h
+
+#include <z_io_proc_data.h>
+
+#include <wave_format.h>
+#include <wave_parameters.h>
+#define z_export_default_wave_format wave_format_microsoft_pcm_format
+#define z_export_default_length_channels 0x01
+#define z_export_default_bytes_sample 0x02
+#define z_export_default_rate_samples 0xac44
+
+unsigned int z_export_length_samples_get(
+  unsigned short int,
+  unsigned int,
+  unsigned int
+);
+unsigned char z_export(
+  char*,
+  struct z_io_proc_data*
+);
+
+unsigned char z_export_with_parameters(
+  char*,
+  struct z_io_proc_data*,
+  struct wave_parameters*
+);
+#endif

--- a/sources/z.c
+++ b/sources/z.c
@@ -3,6 +3,7 @@
 #include <z_close_exit.h>
 #include <z_display_thread.h>
 #include <z_event.h>
+#include <z_export.h>
 #include <z_initializer.h>
 #include <z_io_proc.h>
 #include <z_io_proc_data.h>
@@ -16,17 +17,6 @@
 
 #include <interrupt_handler.h>
 
-#include <math_c_minimum.h>
-
-#include <wave_chunk_data.h>
-#include <wave_chunk_fact.h>
-#include <wave_chunk_fmt.h>
-#include <wave_chunk_riff.h>
-#include <wave_format.h>
-#include <wave_parameters.h>
-
-#include <CoreAudio/CoreAudio.h>
-
 #include <pthread.h>
 #include <stdio.h>
 
@@ -38,78 +28,15 @@ int main(
     length_parameters ==
     0x02
   ) {
-    FILE* output = (
-      fopen(
-        parameters[
-          0x01
-        ],
-        "wb"
-      )
-    );
-
-    if (
-      output ==
-      0x00
-    ) {
-      fprintf(
-        stderr,
-        "failed_to_open->{%s};\n",
-        parameters[
-          0x01
-        ]
-      );
-
-      return (
-        0x01
-      );
-    }
-
     static struct z_track_parameters z_track_parameters;
     static struct z_io_proc_data z_io_proc_data;
-
-    struct wave_parameters wave_parameters = {
-      .wave_format = (
-        wave_format_microsoft_pcm_format
-      ),
-      .length_channels = (
-        0x01
-      ),
-      .rate_samples = (
-        0xac44
-      ),
-      .bytes_sample = (
-        0x02
-      ),
-      .length_samples = (
-        0x4affff
-      )
-    };
-
-    struct wave_chunk_data chunk_data;
-    struct wave_chunk_fmt chunk_fmt;
-    struct wave_chunk_riff chunk_riff;
-
-    wave_chunk_riff_initialize(
-      &chunk_riff,
-      &wave_parameters
-    );
-
-    wave_chunk_fmt_initialize(
-      &chunk_fmt,
-      &wave_parameters
-    );
-
-    wave_chunk_data_initialize(
-      &chunk_data,
-      &wave_parameters
-    );
 
     z_track_parameters_initialize_defaults(
       &z_track_parameters
     );
 
     float rate_samples = (
-      wave_parameters.rate_samples *
+      z_export_default_rate_samples *
       0x02
     );
 
@@ -125,172 +52,28 @@ int main(
       z_io_proc_data.rate_sample
     );
 
-    unsigned char* bytes = (
-      clic3_memory_allocate_raw(
-        wave_parameters.bytes_sample
+    unsigned char status_export = (
+      z_export(
+        parameters[
+          0x01
+        ],
+        &z_io_proc_data
       )
     );
-
-    float* buffer = (
-      clic3_memory_allocate_raw(
-        wave_parameters.length_samples *
-        wave_parameters.length_channels *
-        sizeof(
-          float
-        )
-      )
-    );
-
-    unsigned long int maximum_bytes = (
+    
+    if (
+      status_export !=
       0x00
-    );
-
-    for (
-      unsigned char index_byte = (
-        0x00
-      );
-      (
-        index_byte <
-        wave_parameters.bytes_sample
-      );
-      ++index_byte
     ) {
-      maximum_bytes = (
-        (
-          maximum_bytes <<
-          0x08
-        ) +
-        0xff
+      fprintf(
+        stderr,
+        "failed_to_export.to->{%s};\n",
+        parameters[
+          0x01
+        ]
       );
     }
-
-    for (
-      unsigned long long int frame = (
-        0x00
-      );
-      (
-        frame <
-        wave_parameters.length_samples *
-        wave_parameters.length_channels
-      );
-      ++frame
-    ) {
-      unsigned long int index_data = (
-        frame *
-        wave_parameters.bytes_sample
-      );
-
-      unsigned long int value = (
-        0x00
-      );
-
-      unsigned long int index = (
-        frame /
-        wave_parameters.length_channels
-      );
-
-      if (
-        (
-          frame %
-          wave_parameters.length_channels
-        ) ==
-        0x00
-      ){
-        z_io_proc_frame_get(
-          &z_io_proc_data,
-          &z_io_proc_data.queue,
-          buffer,
-          index,
-          0x00
-        );
-
-        value = (
-          (
-            buffer[
-              index
-            ] +
-            0x01
-          ) /
-          0x02 *
-          maximum_bytes
-        );
-      } else {
-        value = (
-          (
-            buffer[
-              index
-            ] +
-            0x01
-          ) /
-          0x02 *
-          maximum_bytes
-        );
-      }
-
-      value = (
-        value /
-        0x02
-      );
-
-      for (
-        unsigned int index_byte = (
-          0x00
-        );
-        (
-          index_byte <
-          wave_parameters.bytes_sample
-        );
-        ++index_byte
-      ) {
-        chunk_data.data[
-          index_data +
-          index_byte
-        ] = (
-          (
-            (unsigned char*)
-            &value
-          )[
-            index_byte
-          ]
-        );
-      }
-    }
-
-    clic3_memory_free_raw(
-      bytes
-    );
-
-    wave_chunk_riff_write(
-      &chunk_riff,
-      output
-    );
-
-    wave_chunk_fmt_write(
-      &chunk_fmt,
-      output
-    );
-
-    wave_chunk_data_write(
-      &chunk_data,
-      output
-    );
-
-    fclose(
-      output
-    );
-
-    wave_chunk_riff_destroy(
-      &chunk_riff
-    );
-
-    wave_chunk_fmt_destroy(
-      &chunk_fmt
-    );
-
-    wave_chunk_data_destroy(
-      &chunk_data
-    );
-
+    
     z_queue_destroy(
       &z_io_proc_data.queue
     );
@@ -300,7 +83,7 @@ int main(
     );
 
     return (
-      0x00
+      status_export
     );
   } else if (
     length_parameters !=

--- a/sources/z_export.c
+++ b/sources/z_export.c
@@ -1,0 +1,263 @@
+#include <z_export.h>
+
+#include <z_io_proc.h>
+#include <z_io_proc_data.h>
+
+#include <clic3_memory.h>
+
+#include <wave_chunk_data.h>
+#include <wave_chunk_fact.h>
+#include <wave_chunk_fmt.h>
+#include <wave_chunk_riff.h>
+#include <wave_format.h>
+#include <wave_parameters.h>
+
+#include <stdio.h>
+
+unsigned int z_export_length_samples_get(
+  unsigned short int bytes_sample,
+  unsigned int length_channels,
+  unsigned int length
+) {
+  return (
+    bytes_sample *
+    length_channels *
+    length *    0x64
+  );
+}
+
+unsigned char z_export(
+  char* path_file_export,
+  struct z_io_proc_data* z_io_proc_data
+) {
+  struct wave_parameters wave_parameters = {
+    .wave_format = (
+      z_export_default_wave_format
+    ),
+    .length_channels = (
+      z_export_default_length_channels
+    ),
+    .rate_samples = (
+      z_export_default_rate_samples
+    ),
+    .bytes_sample = (
+      z_export_default_bytes_sample
+    ),
+    .length_samples = (
+      z_export_length_samples_get(
+        z_export_default_bytes_sample,
+        z_export_default_length_channels,
+        z_io_proc_data->queue.track_current->length
+      )
+    )
+  };
+
+  return (
+    z_export_with_parameters(
+      path_file_export,
+      z_io_proc_data,
+      &wave_parameters
+    )
+  );
+}
+
+unsigned char z_export_with_parameters(
+  char* path_file_export,
+  struct z_io_proc_data* z_io_proc_data,
+  struct wave_parameters* wave_parameters
+) {
+  FILE* output = (
+    fopen(
+      path_file_export,
+      "wb"
+    )
+  );
+
+  if (
+    output ==
+    0x00
+  ) {
+    return (
+      0x01
+    );
+  }
+
+  struct wave_chunk_data chunk_data;
+  struct wave_chunk_fmt chunk_fmt;
+  struct wave_chunk_riff chunk_riff;
+
+  wave_chunk_riff_initialize(
+    &chunk_riff,
+    wave_parameters
+  );
+
+  wave_chunk_fmt_initialize(
+    &chunk_fmt,
+    wave_parameters
+  );
+
+  wave_chunk_data_initialize(
+    &chunk_data,
+    wave_parameters
+  );
+
+  float rate_samples = (
+    wave_parameters->rate_samples *
+    0x02
+  );
+
+  unsigned char* bytes = (
+    clic3_memory_allocate_raw(
+      wave_parameters->bytes_sample
+    )
+  );
+
+  unsigned long int maximum_bytes = (
+    0x00
+  );
+
+  for (
+    unsigned char index_byte = (
+      0x00
+    );
+    (
+      index_byte <
+      wave_parameters->bytes_sample
+    );
+    ++index_byte
+  ) {
+    maximum_bytes = (
+      (
+        maximum_bytes <<
+        0x08
+      ) +
+      0xff
+    );
+  }
+
+  for (
+    unsigned long long int frame = (
+      0x00
+    );
+    (
+      frame <
+      wave_parameters->length_samples *
+      wave_parameters->length_channels
+    );
+    ++frame
+  ) {
+    unsigned long int index_data = (
+      frame *
+      wave_parameters->bytes_sample
+    );
+
+    unsigned long int value = (
+      0x00
+    );
+
+    unsigned long int index = (
+      frame /
+      wave_parameters->length_channels
+    );
+
+    if (
+      (
+        frame %
+        wave_parameters->length_channels
+      ) ==
+      0x00
+    ){
+      z_io_proc_data->frame = (
+        z_io_proc_data->frame +
+        0x01
+      );
+    
+      float value_frame = (
+        z_io_proc_frame_value_get(
+          z_io_proc_data,
+          &z_io_proc_data->queue
+        )
+      );
+      value = (
+        (
+          value_frame +
+          0x01
+        ) /
+        0x02 *
+        maximum_bytes
+      );
+    } else {
+      value = (
+        (
+          value +
+          0x01
+        ) /
+        0x02 *
+        maximum_bytes
+      );
+    }
+
+    value = (
+      value /
+      0x02
+    );
+
+    for (
+      unsigned int index_byte = (
+        0x00
+      );
+      (
+        index_byte <
+        wave_parameters->bytes_sample
+      );
+      ++index_byte
+    ) {
+      chunk_data.data[
+        index_data +
+        index_byte
+      ] = (
+        (
+          (unsigned char*)
+          &value
+        )[
+          index_byte
+        ]
+      );
+    }
+  }
+
+  wave_chunk_riff_write(
+    &chunk_riff,
+    output
+  );
+
+  wave_chunk_fmt_write(
+    &chunk_fmt,
+    output
+  );
+
+  wave_chunk_data_write(
+    &chunk_data,
+    output
+  );
+
+  fclose(
+    output
+  );
+
+  wave_chunk_riff_destroy(
+    &chunk_riff
+  );
+
+  wave_chunk_fmt_destroy(
+    &chunk_fmt
+  );
+
+  wave_chunk_data_destroy(
+    &chunk_data
+  );
+
+  return (
+    0x00
+  );
+}

--- a/sources/z_track.c
+++ b/sources/z_track.c
@@ -564,7 +564,7 @@ void z_track_generate(
     effect_delay_data_third->decay = (
       0.4f
     );
-  
+
     effect_delay_third->mix = (
       0.5f
     );

--- a/sources/z_track_parameters.c
+++ b/sources/z_track_parameters.c
@@ -47,7 +47,7 @@ const struct z_track_parameters z_track_parameters_defaults = {
     cer0_frequency_root_scientific
   ),
   .octave_minimum = (
-    0x01
+    0x02
   ),
   .octave_maximum = (
     0x06


### PR DESCRIPTION
- `z_export`:add
- `z_track_parameters`:`octave_minimum`.from->{`0x01`}.to->{`0x02`};
- `z`:use->{`z_export`};

## example_exports

these have a track multiplier set to `3.15f` to fit the size limit

[a.wav](https://github.com/user-attachments/files/27847327/a.wav)
[c.wav](https://github.com/user-attachments/files/27847286/c.wav)
[b.wav](https://github.com/user-attachments/files/27847294/b.wav)
