### PR TITLE
[dev] Z io proc further modularization

### DIFF
--- a/include/z_export.h
+++ b/include/z_export.h
@@ -1,13 +1,14 @@
 #ifndef __z_export_h
 #define __z_export_h
 
-#include <z_io_proc_data.h>
+#include <z_track.h>
 
 #include <wave_format.h>
 #include <wave_parameters.h>
+
 #define z_export_default_wave_format wave_format_microsoft_pcm_format
-#define z_export_default_length_channels 0x01
-#define z_export_default_bytes_sample 0x02
+#define z_export_default_length_channels 0x02
+#define z_export_default_bytes_sample 0x04
 #define z_export_default_rate_samples 0xac44
 
 unsigned int z_export_length_samples_get(
@@ -17,12 +18,12 @@ unsigned int z_export_length_samples_get(
 );
 unsigned char z_export(
   char*,
-  struct z_io_proc_data*
+  struct z_track*
 );
 
 unsigned char z_export_with_parameters(
   char*,
-  struct z_io_proc_data*,
+  struct z_track*,
   struct wave_parameters*
 );
 #endif

--- a/include/z_io_proc.h
+++ b/include/z_io_proc.h
@@ -3,6 +3,7 @@
 
 #include <z_io_proc_data.h>
 #include <z_queue.h>
+#include <z_track.h>
 
 #if target_os_ios
 #else
@@ -28,8 +29,13 @@ int z_io_proc(
 #endif
 
 float z_io_proc_frame_value_get(
-  struct z_io_proc_data*,
-  struct z_queue*
+  struct z_track*,
+  unsigned long long int,
+  float);
+
+float z_io_proc_frame_volume_apply(
+  float,
+  float
 );
 
 void z_io_proc_frame_get(

--- a/sources/z.c
+++ b/sources/z.c
@@ -28,28 +28,17 @@ int main(
     length_parameters ==
     0x02
   ) {
-    static struct z_track_parameters z_track_parameters;
-    static struct z_io_proc_data z_io_proc_data;
+    struct z_track_parameters z_track_parameters;
+    struct z_track z_track;
 
     z_track_parameters_initialize_defaults(
       &z_track_parameters
     );
 
-    float rate_samples = (
-      z_export_default_rate_samples *
-      0x02
-    );
-
-    z_io_proc_data_initialize(
-      &z_io_proc_data,
+    z_track_generate(
+      &z_track,
       &z_track_parameters,
-      &rate_samples
-    );
-
-    z_queue_initialize(
-      &z_io_proc_data.queue,
-      z_io_proc_data.track_parameters,
-      z_io_proc_data.rate_sample
+      z_export_default_rate_samples
     );
 
     unsigned char status_export = (
@@ -57,7 +46,7 @@ int main(
         parameters[
           0x01
         ],
-        &z_io_proc_data
+        &z_track
       )
     );
 
@@ -73,10 +62,6 @@ int main(
         ]
       );
     }
-
-    z_queue_destroy(
-      &z_io_proc_data.queue
-    );
 
     z_track_parameters_destroy(
       &z_track_parameters

--- a/sources/z.c
+++ b/sources/z.c
@@ -60,7 +60,7 @@ int main(
         &z_io_proc_data
       )
     );
-    
+
     if (
       status_export !=
       0x00
@@ -73,7 +73,7 @@ int main(
         ]
       );
     }
-    
+
     z_queue_destroy(
       &z_io_proc_data.queue
     );

--- a/sources/z_export.c
+++ b/sources/z_export.c
@@ -29,7 +29,7 @@ unsigned int z_export_length_samples_get(
 
 unsigned char z_export(
   char* path_file_export,
-  struct z_io_proc_data* z_io_proc_data
+  struct z_track* z_track
 ) {
   struct wave_parameters wave_parameters = {
     .wave_format = (
@@ -48,7 +48,7 @@ unsigned char z_export(
       z_export_length_samples_get(
         z_export_default_bytes_sample,
         z_export_default_length_channels,
-        z_io_proc_data->queue.track_current->length
+        z_track->length
       )
     )
   };
@@ -56,7 +56,7 @@ unsigned char z_export(
   return (
     z_export_with_parameters(
       path_file_export,
-      z_io_proc_data,
+      z_track,
       &wave_parameters
     )
   );
@@ -64,7 +64,7 @@ unsigned char z_export(
 
 unsigned char z_export_with_parameters(
   char* path_file_export,
-  struct z_io_proc_data* z_io_proc_data,
+  struct z_track* z_track,
   struct wave_parameters* wave_parameters
 ) {
   FILE* output = (
@@ -168,15 +168,13 @@ unsigned char z_export_with_parameters(
       ) ==
       0x00
     ){
-      z_io_proc_data->frame = (
-        z_io_proc_data->frame +
-        0x01
-      );
-
       float value_frame = (
         z_io_proc_frame_value_get(
-          z_io_proc_data->queue.track_current,
-          z_io_proc_data->frame,
+          z_track,
+          (
+            frame /
+            wave_parameters->length_channels
+          ),
           rate_samples
         )
       );

--- a/sources/z_export.c
+++ b/sources/z_export.c
@@ -175,8 +175,9 @@ unsigned char z_export_with_parameters(
 
       float value_frame = (
         z_io_proc_frame_value_get(
-          z_io_proc_data,
-          &z_io_proc_data->queue
+          z_io_proc_data->queue.track_current,
+          z_io_proc_data->frame,
+          rate_samples
         )
       );
 

--- a/sources/z_io_proc.c
+++ b/sources/z_io_proc.c
@@ -271,8 +271,9 @@ int z_io_proc(
 #endif
 
 float z_io_proc_frame_value_get(
-  struct z_io_proc_data* z_io_proc_data,
-  struct z_queue* z_queue
+  struct z_track* z_track,
+  unsigned long long int index_frame,
+  float rate_sample
 ) {
   float value = (
     0x00
@@ -284,12 +285,12 @@ float z_io_proc_frame_value_get(
     );
     (
       index_lane <
-      z_queue->track_current->length_lanes
+      z_track->length_lanes
     );
     ++index_lane
   ) {
     struct z_track_lane* track_lane = &(
-      z_queue->track_current->lanes[
+      z_track->lanes[
         index_lane
       ]
     );
@@ -306,7 +307,7 @@ float z_io_proc_frame_value_get(
 
     unsigned long int note_life_end = (
       (
-        *z_io_proc_data->rate_sample /
+        rate_sample /
         0x0258
       ) *
       note->time
@@ -314,7 +315,7 @@ float z_io_proc_frame_value_get(
 
     unsigned long int note_life = (
       (
-        z_io_proc_data->frame +
+        index_frame +
         0x01
       ) %
       note_life_end
@@ -348,11 +349,11 @@ float z_io_proc_frame_value_get(
 
       track_lane->synthesizer.length_attack_sustain_decay_release = (
         (
-          *z_io_proc_data->rate_sample /
+          rate_sample /
           0x0258
         ) *
         note->time -
-        z_io_proc_data->frame
+        index_frame
       );
 
       cer0_synthesizer_frequency_play(
@@ -371,18 +372,19 @@ float z_io_proc_frame_value_get(
   }
 
   return (
-    math_c_minimum_float(
-      math_c_maximum_float(
-        (
-          value /
-          (float)
-          z_queue->track_current->length_lanes
-        ) *
-        z_io_proc_data->settings.volume,
-        -0x01
-      ),
-      0x01
-    )
+    value /
+    (float)
+    z_track->length_lanes
+  );
+}
+
+float z_io_proc_frame_volume_apply(
+  float frame_value,
+  float volume
+) {
+  return (
+    frame_value *
+    volume
   );
 }
 
@@ -406,9 +408,13 @@ void z_io_proc_frame_get(
   buffer_out[
     index_buffer_out
   ] = (
-    z_io_proc_frame_value_get(
-      z_io_proc_data,
-      z_queue
+    z_io_proc_frame_volume_apply(
+      z_io_proc_frame_value_get(
+        z_queue->track_current,
+        z_io_proc_data->frame,
+        *z_queue->rate_sample
+      ),
+      z_io_proc_data->settings.volume
     )
   );
 


### PR DESCRIPTION
- `z_io_proc`
- - `z_io_proc_frame_value_get`
- - - reduce parameters to only those needed
- - - - allows for frame value gets on a single track without needing `z_io_proc_data` or `z_queue`
- - `z_io_proc_frame_volume_apply`
- - - function to apply volume values
