### PR TITLE
[dev] `z_export`:use_only_track_during_export_generation

### DIFF
--- a/include/z_export.h
+++ b/include/z_export.h
@@ -1,13 +1,14 @@
 #ifndef __z_export_h
 #define __z_export_h
 
-#include <z_io_proc_data.h>
+#include <z_track.h>
 
 #include <wave_format.h>
 #include <wave_parameters.h>
+
 #define z_export_default_wave_format wave_format_microsoft_pcm_format
-#define z_export_default_length_channels 0x01
-#define z_export_default_bytes_sample 0x02
+#define z_export_default_length_channels 0x02
+#define z_export_default_bytes_sample 0x04
 #define z_export_default_rate_samples 0xac44
 
 unsigned int z_export_length_samples_get(
@@ -17,12 +18,12 @@ unsigned int z_export_length_samples_get(
 );
 unsigned char z_export(
   char*,
-  struct z_io_proc_data*
+  struct z_track*
 );
 
 unsigned char z_export_with_parameters(
   char*,
-  struct z_io_proc_data*,
+  struct z_track*,
   struct wave_parameters*
 );
 #endif

--- a/sources/z.c
+++ b/sources/z.c
@@ -28,28 +28,17 @@ int main(
     length_parameters ==
     0x02
   ) {
-    static struct z_track_parameters z_track_parameters;
-    static struct z_io_proc_data z_io_proc_data;
+    struct z_track_parameters z_track_parameters;
+    struct z_track z_track;
 
     z_track_parameters_initialize_defaults(
       &z_track_parameters
     );
 
-    float rate_samples = (
-      z_export_default_rate_samples *
-      0x02
-    );
-
-    z_io_proc_data_initialize(
-      &z_io_proc_data,
+    z_track_generate(
+      &z_track,
       &z_track_parameters,
-      &rate_samples
-    );
-
-    z_queue_initialize(
-      &z_io_proc_data.queue,
-      z_io_proc_data.track_parameters,
-      z_io_proc_data.rate_sample
+      z_export_default_rate_samples
     );
 
     unsigned char status_export = (
@@ -57,7 +46,7 @@ int main(
         parameters[
           0x01
         ],
-        &z_io_proc_data
+        &z_track
       )
     );
 
@@ -73,10 +62,6 @@ int main(
         ]
       );
     }
-
-    z_queue_destroy(
-      &z_io_proc_data.queue
-    );
 
     z_track_parameters_destroy(
       &z_track_parameters

--- a/sources/z_export.c
+++ b/sources/z_export.c
@@ -29,7 +29,7 @@ unsigned int z_export_length_samples_get(
 
 unsigned char z_export(
   char* path_file_export,
-  struct z_io_proc_data* z_io_proc_data
+  struct z_track* z_track
 ) {
   struct wave_parameters wave_parameters = {
     .wave_format = (
@@ -48,7 +48,7 @@ unsigned char z_export(
       z_export_length_samples_get(
         z_export_default_bytes_sample,
         z_export_default_length_channels,
-        z_io_proc_data->queue.track_current->length
+        z_track->length
       )
     )
   };
@@ -56,7 +56,7 @@ unsigned char z_export(
   return (
     z_export_with_parameters(
       path_file_export,
-      z_io_proc_data,
+      z_track,
       &wave_parameters
     )
   );
@@ -64,7 +64,7 @@ unsigned char z_export(
 
 unsigned char z_export_with_parameters(
   char* path_file_export,
-  struct z_io_proc_data* z_io_proc_data,
+  struct z_track* z_track,
   struct wave_parameters* wave_parameters
 ) {
   FILE* output = (
@@ -168,15 +168,13 @@ unsigned char z_export_with_parameters(
       ) ==
       0x00
     ){
-      z_io_proc_data->frame = (
-        z_io_proc_data->frame +
-        0x01
-      );
-
       float value_frame = (
         z_io_proc_frame_value_get(
-          z_io_proc_data->queue.track_current,
-          z_io_proc_data->frame,
+          z_track,
+          (
+            frame /
+            wave_parameters->length_channels
+          ),
           rate_samples
         )
       );


### PR DESCRIPTION
- `z_export`:use_only_track_during_export_generation