### PR TITLE
[enh] preserve_last_lane_value

### DIFF
--- a/sources/z_io_proc.c
+++ b/sources/z_io_proc.c
@@ -229,11 +229,29 @@ int z_io_proc(
 
         buffer_out_channel_zero_value = (
           buffer_out_channel_zero_value *
-          (            math_c_absolute_float(math_c_sine((float) z_io_proc_data->frame / (((0x3c / 0x01) / z_queue->track_current->bpm * 0x03e8) * (        *z_io_proc_data->rate_sample /
-        0x0258
-      ) * 0x20)  * math_c_pi, math_c_pi)) *
-          0.75f +
-          0.25f)
+          (
+            math_c_absolute_float(
+              math_c_sine(
+                (float) z_io_proc_data->frame /
+                (
+                  (
+                    0x3c /
+                    z_queue->track_current->bpm *
+                    0x03e8
+                  ) *
+                  (
+                    *z_io_proc_data->rate_sample /
+                    0x0258
+                  ) *
+                  0x20
+                )  *
+                math_c_pi,
+                math_c_pi
+              )
+            ) *
+            0.75f +
+            0.25f
+          )
         );
 
         buffer_out[
@@ -277,6 +295,10 @@ float z_io_proc_frame_value_get(
   float rate_sample
 ) {
   float value = (
+    0x00
+  );
+
+  float value_last = (
     0x00
   );
 
@@ -415,17 +437,39 @@ float z_io_proc_frame_value_get(
       }
     }
 
-    value = (
-      value +
-      cer0_synthesizer_poll(
-        &track_lane->synthesizer
-      ) *
-      note->amplitude
-    );
+    if (
+      index_lane ==
+      (
+        z_track->length_lanes -
+        0x01
+      )
+    ) {
+      value_last = (
+        value_last +
+        cer0_synthesizer_poll(
+          &track_lane->synthesizer
+        ) *
+        note->amplitude
+      );
+    } else {
+      value = (
+        value +
+        cer0_synthesizer_poll(
+          &track_lane->synthesizer
+        ) *
+        note->amplitude
+      );
+    }
   }
 
   value = (
     value /
+    (float)
+    z_track->length_lanes
+  );
+
+  value_last = (
+    value_last /
     (float)
     z_track->length_lanes
   );
@@ -449,18 +493,11 @@ float z_io_proc_frame_value_get(
         value
       )
     );
-    
-    /*value = (
-      math_c_bound_float(
-        value,
-        0x01,
-        -0x01
-      )    );*/
-        
   }
 
   return (
-    value
+    value +
+    value_last
   );
 }
 

--- a/sources/z_track.c
+++ b/sources/z_track.c
@@ -84,7 +84,7 @@ void z_track_generate(
     rand_source_divisive_data->length_seed *
     0x02
   );
-  
+
   track->char_array_seed = (
     clic3_memory_allocate_raw(
       track->length_char_array_seed +
@@ -302,7 +302,7 @@ void z_track_generate(
     ],
     0x08
   );
-  
+
   track->effects[
       0x02
     ].mix = (
@@ -313,13 +313,13 @@ void z_track_generate(
       0x01
     ]
   );
-  
+
   track->effects[
     0x01
   ].mix = (
     0.25f
   );
-  
+
   cer0_effect_delay_length_frames_buffer_set(
     &track->effects[
       0x01
@@ -336,29 +336,29 @@ void z_track_generate(
   effect_delay_data->decay = (
     0.6969f
   );
-  
+
   cer0_effect_distortion_initialize(
     &track->effects[
       0x00
     ]
   );
-  
+
   struct cer0_effect_distortion_data* j = (
     track->effects[0x00].data
   );
-  
+
   j->noise = (
     0.006f
   );
-  
+
   track->effects[0x00].mix = (0.125f);
-  
+
   cer0_effect_delay_initialize(
     &track->effects[
       0x03
     ]
   );
- 
+
   for (
     unsigned char u = 0;
     u < 0x03;
@@ -369,13 +369,13 @@ void z_track_generate(
       0x03 + u
     ]
   );
-  
+
   track->effects[
     0x03 + u
   ].mix = (
     0.25f + (u * 0.25f)
   );
-  
+
   cer0_effect_delay_length_frames_buffer_set(
     &track->effects[
       0x03 + u
@@ -393,14 +393,14 @@ void z_track_generate(
     0.3f * ( u + 1)
   );
   }
-  
+
   cer0_effect_bit_crush_initialize(
     &track->effects[
       0x06
     ],
     0x08
   );
-  
+
   track->effects[
       0x06
     ].mix = (
@@ -413,7 +413,7 @@ void z_track_generate(
     ],
     cer0_effect_bit_crush_mode_bits
   );
-  
+
   for (
     unsigned char index_track_name = (
       0x00
@@ -478,7 +478,7 @@ void z_track_generate(
       }
     }
   }
-  
+
   track->name[    length_track_name -
     0x01
   ] = (

--- a/sources/z_track_parameters.c
+++ b/sources/z_track_parameters.c
@@ -63,7 +63,7 @@ const struct z_track_parameters z_track_parameters_defaults = {
     0x0a
   ),
   .track_length_lanes_maximum = (
-    0x40
+    0x0a
   ),
   .frequency_root = (
     cer0_frequency_root_scientific
@@ -87,7 +87,7 @@ const struct z_track_parameters z_track_parameters_defaults = {
     z_track_parameters_length_types_default
   ),
   .track_length_multiplier = (
-    16.0f
+    0x10
   ),
   .track_bpm_minimum = (
     0x02
@@ -99,13 +99,13 @@ const struct z_track_parameters z_track_parameters_defaults = {
     0.825f
   ),
   .oscillator_amplitude_maximum = (
-    1.0f
+    0x01
   ),
   .note_amplitude_minimum = (
     0.125f
   ),
   .note_amplitude_maximum = (
-    1.0f
+    0x01
   )
 };
 


### PR DESCRIPTION
- `z_io_proc`:preserve last lane value
- - allows a layer of singular notes to be audible over the sloshing wave like sounds beneath them